### PR TITLE
docs: explain offline pnpm dependency caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,18 @@ node ./dist/cli.js
 pnpm link
 ```
 
+To support offline installs, you can prefetch dependencies and commit the resulting cache:
+
+```bash
+# Populate the pnpm store with packages from pnpm-lock.yaml
+pnpm fetch
+
+# Commit the generated .pnpm-store directory or mirror your registry
+
+# Later, install using only cached packages
+pnpm install --offline
+```
+
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- document prefetching dependencies with `pnpm fetch`
- add notes on committing `.pnpm-store` or using a local registry mirror
- show how to use the cached store with `pnpm install --offline`

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test` *(fails: markdown tests and raw exec process group test)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb455338832bbfb7702f53d79804